### PR TITLE
🐛 Updated attched log file name when encounter fatal error

### DIFF
--- a/Core/Bot/diagnosticlog.js
+++ b/Core/Bot/diagnosticlog.js
@@ -155,8 +155,8 @@ let DiagnosticLog = {
             }
         })
     },
-    generateSnapshotFilename: (file, midfix = "", snapshotDir = "cache/logs") => {
-        return path.join(snapshotDir, `${new Date().getTime()}-${midfix.length === 0 ? "" : midfix + "-"}` + path.basename(file))
+    generateSnapshotFilename: (file, postfix = "", snapshotDir = "cache/logs") => {
+        return path.join(snapshotDir, path.basename(file).replace(".log", "") + `${postfix.length === 0 ? "" : "-" + postfix}` + ".log")
     },
     snapshotLogFile: (file, midfix = "", snapshotDir = "cache/logs") => {
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
New format will be

`${config.botname}-Core-Log-${logTime}-partial.log`
`${config.botname}-Message-Log-${logTime}-partial.log`

Signed-off-by: Cocoa <0xbbc@0xbbc.com>